### PR TITLE
Add bot type detection and map colors + fix SAIN mod detection

### DIFF
--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -64,6 +64,7 @@ namespace RAID_REVIEW
         public static GameObject Hook;
 
         // Other Mods
+        public static bool MODS_SEARCHED = false;
         public static bool SOLARINT_SAIN__DETECTED { get; private set; }
 
         void Awake()
@@ -98,16 +99,6 @@ namespace RAID_REVIEW
 
             Telemetry.Connect(RAID_REVIEW_WS_Server);
             Logger.LogInfo("RAID_REVIEW :::: INFO :::: Connected to backend");
-
-            Logger.LogInfo("RAID_REVIEW :::: INFO :::: Searching For Supported Mods");
-            if (Chainloader.PluginInfos.ContainsKey("me.sol.sain"))
-            {
-                Logger.LogInfo("RAID_REVIEW :::: INFO :::: Found 'SAIN' Enabling Plugin Features for SAIN.");
-                SOLARINT_SAIN__DETECTED = true;
-                RAID_REVIEW__DETECTED_MODS.Add("SAIN");
-                ExtractTracking = Config.Bind<bool>("Tracking Settings", "Extract Tracking", true, "Enables location tracking of players and bots extraction activities.");
-            }
-            Logger.LogInfo("RAID_REVIEW :::: INFO :::: Finished Searching For Supported Mods");
         }
         void Update()
         {
@@ -139,6 +130,17 @@ namespace RAID_REVIEW
                 // RAID START
                 if (!inRaid && !stopwatch.IsRunning)
                 {
+                    if (!MODS_SEARCHED)
+                    {
+                        Logger.LogInfo("RAID_REVIEW :::: INFO :::: Searching For Supported Mods");
+                        MODS_SEARCHED = true;
+                        if (DetectMod("me.sol.sain"))
+                        {
+                            Logger.LogInfo("RAID_REVIEW :::: INFO :::: Found 'SAIN' Enabling Plugin Features for SAIN.");
+                            SOLARINT_SAIN__DETECTED = true;
+                        }
+                        Logger.LogInfo("RAID_REVIEW :::: INFO :::: Finished Searching For Supported Mods");
+                    }
                     Logger.LogInfo("RAID_REVIEW :::: INFO :::: RAID Settings Loaded");
 
                     inRaid = true;
@@ -316,6 +318,12 @@ namespace RAID_REVIEW
             var context = new ValidationContext(data, null, null);
             validationResults = new List<ValidationResult>();
             return Validator.TryValidateObject(data, context, validationResults, true);
+        }
+
+        public static bool DetectMod(string modName)
+        {
+            if (Chainloader.PluginInfos.ContainsKey(modName)) return true;
+            return false;
         }
 
         public static bool MapLoaded() => Singleton<GameWorld>.Instantiated;

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -212,12 +212,11 @@ namespace RAID_REVIEW
                             {
                                 var brain = botComponent.Info.Personality;
                                 trackingPlayer.mod_SAIN_brain = Enum.GetName(typeof(EPersonality), brain);
+                                if (botComponent.Info.Profile.IsScav) trackingPlayer.type = "SCAV";
+                                else if (botComponent.Info.Profile.IsBoss) trackingPlayer.type = "BOSS";
+                                else if (botComponent.Info.Profile.IsFollower) trackingPlayer.type = "RAIDER";
+                                else if (botComponent.Info.Profile.IsPlayerScav) trackingPlayer.type = "PLAYER_SCAV";
                             }
-
-                            if (botComponent.Info.Profile.IsScav) trackingPlayer.type = "SCAV";
-                            else if (botComponent.Info.Profile.IsBoss) trackingPlayer.type = "BOSS";
-                            else if (botComponent.Info.Profile.IsFollower) trackingPlayer.type = "RAIDER";
-                            else if (botComponent.Info.Profile.IsPlayerScav) trackingPlayer.type = "PLAYER_SCAV";
                         }
                         else
                         {

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -211,10 +211,15 @@ namespace RAID_REVIEW
                                 var brain = botComponent.Info.Personality;
                                 trackingPlayer.mod_SAIN_brain = Enum.GetName(typeof(EPersonality), brain);
                             }
+
+                            if (botComponent.Info.Profile.IsScav) trackingPlayer.type = "SCAV";
+                            else if (botComponent.Info.Profile.IsBoss) trackingPlayer.type = "BOSS";
+                            else if (botComponent.Info.Profile.IsFollower) trackingPlayer.type = "RAIDER";
+                            else if (botComponent.Info.Profile.IsPlayerScav) trackingPlayer.type = "PLAYER_SCAV";
                         }
                         else
                         {
-                            trackingPlayer.mod_SAIN_brain = player.IsAI ? trackingPlayer.mod_SAIN_brain = "SCAV" : trackingPlayer.mod_SAIN_brain = "PLAYER";
+                            trackingPlayer.mod_SAIN_brain = player.Side == EPlayerSide.Savage ? trackingPlayer.mod_SAIN_brain = "SCAV" : trackingPlayer.mod_SAIN_brain = "PMC";
                         }
 
                         trackingPlayers[trackingPlayer.profileId] = trackingPlayer;

--- a/Server/src/Controllers/Database/migrations/202406180100_add_type_to_player.sql
+++ b/Server/src/Controllers/Database/migrations/202406180100_add_type_to_player.sql
@@ -1,0 +1,2 @@
+ALTER TABLE player
+ADD "type" TEXT;

--- a/Server/src/Web/Client/src/component/Map.tsx
+++ b/Server/src/Web/Client/src/component/Map.tsx
@@ -151,17 +151,17 @@ function calculateProportionalRadius(mapBounds) {
   
 const colors = [
     "#3357FF", // Blue
-    "#FF5733", // Red-Orange
-    "#FFFF99", // Canary
-    "#FF33A1", // Pink
-    "#33FFF3", // Cyan
-    "#FF33E9", // Magenta
     "#FFD433", // Yellow
+    "#33FFF3", // Cyan
+    "#9370DB", // MediumPurple
+    "#BC8F8F", // RosyBrown
+    "#FF5733", // Red-Orange
     "#7FFFD4", // Aquamarine
-    "#B87333", // Copper
+    "#FFFF99", // Canary
+    "#FF3380", // Hot Pink
     "#FF9633", // Orange
     "#3366FF", // Royal Blue
-    "#FF3380", // Hot Pink
+    "#B87333", // Copper
     "#FFA533", // Light Orange
     "#33FFAF", // Mint Green
     "#5733FF", // Indigo
@@ -716,9 +716,9 @@ export default function Map({ raidData, profileId, raidId, positions }) {
             case 'SCAV':
                 return "#33FF57"; // Green - Scav
             case 'BOSS':
-                return "#FF3333"; // Red - Boss
+                return "#FF0000"; // Red - Boss
             case 'RAIDER':
-                return "#8D33FF"; // Purple - Raider
+                return "#FF00FF"; // Magenta - Raider
             case 'PLAYER_SCAV':
                 return "#33FF8D"; // Light Green - Scav Player
             default:

--- a/Server/src/Web/Client/src/component/Map.tsx
+++ b/Server/src/Web/Client/src/component/Map.tsx
@@ -157,8 +157,8 @@ const colors = [
     "#33FFF3", // Cyan
     "#FF33E9", // Magenta
     "#FFD433", // Yellow
-    "#8D33FF", // Purple //TODO: Reserved for Raiders so need to make sure it's not used by players
-    "#33FF8D", // Light Green
+    "#7FFFD4", // Aquamarine
+    "#B87333", // Copper
     "#FF9633", // Orange
     "#3366FF", // Royal Blue
     "#FF3380", // Hot Pink
@@ -173,7 +173,7 @@ const colors = [
     "#B833FF", // Violet
     "#33FF57", // Lime
     "#33FF57", // Forest Green
-    "#FF3333", // Red //TODO: Reserved for bosses so need to make sure it's not used by players
+    "#660000", // Blood red
     "#3399FF", // Sky Blue
     "#FF33B8", // Rose
     "#8CFF33", // Lime Green
@@ -690,19 +690,41 @@ export default function Map({ raidData, profileId, raidId, positions }) {
 
     function getPlayerBrain(player: TrackingRaidDataPlayers): string {
         if(player) {
-          if (player.team === 'Savage') {
-            return "(SCAV)";
-          } else if(player.mod_SAIN_brain === "UNKNOWN" && (player.team === "Bear" || player.team === "Usec")) {
-            return "(PMC)"
-          }
-          else return player.mod_SAIN_brain != null ? `(${player.mod_SAIN_brain})` : "(PMC)"
+            switch (player.type){
+                case 'SCAV':
+                    return "(SCAV)"
+                case 'BOSS':
+                    return "(BOSS)"
+                case 'RAIDER':
+                    return "(RAIDER)"
+                case 'PLAYER_SCAV':
+                    return "(PLAYER SCAV)"
+                default:
+                    if(player.mod_SAIN_brain === "UNKNOWN" && (player.team === "Bear" || player.team === "Usec")) {
+                      return "(PMC)"
+                    } else if(player.team === "Savage") {
+                      return "(SCAV)"
+                    } 
+                    return player.mod_SAIN_brain != null ? `(${player.mod_SAIN_brain})` : "(PMC)"
+            }
         }
         return "(UNKNOWN)"
     }
 
     function getPlayerColor(player: TrackingRaidDataPlayers, index: number): string {
-        if (player && player.team === 'Savage') return "#33FF57"; // Green - Scav (bosses and raiders included for now)
-        else return colors[index]; // PMC
+        switch (player.type) {
+            case 'SCAV':
+                return "#33FF57"; // Green - Scav
+            case 'BOSS':
+                return "#FF3333"; // Red - Boss
+            case 'RAIDER':
+                return "#8D33FF"; // Purple - Raider
+            case 'PLAYER_SCAV':
+                return "#33FF8D"; // Light Green - Scav Player
+            default:
+                if (player && player.team === 'Savage') return "#33FF57"; // Green - Scav
+                else return colors[index]; // PMC
+        }
     }
 
     return (

--- a/Server/src/Web/Client/src/component/Map.tsx
+++ b/Server/src/Web/Client/src/component/Map.tsx
@@ -152,12 +152,12 @@ function calculateProportionalRadius(mapBounds) {
 const colors = [
     "#3357FF", // Blue
     "#FF5733", // Red-Orange
-    "#33FF57", // Green
+    "#FFFF99", // Canary
     "#FF33A1", // Pink
     "#33FFF3", // Cyan
     "#FF33E9", // Magenta
     "#FFD433", // Yellow
-    "#8D33FF", // Purple
+    "#8D33FF", // Purple //TODO: Reserved for Raiders so need to make sure it's not used by players
     "#33FF8D", // Light Green
     "#FF9633", // Orange
     "#3366FF", // Royal Blue
@@ -173,7 +173,7 @@ const colors = [
     "#B833FF", // Violet
     "#33FF57", // Lime
     "#33FF57", // Forest Green
-    "#FF3333", // Red
+    "#FF3333", // Red //TODO: Reserved for bosses so need to make sure it's not used by players
     "#3399FF", // Sky Blue
     "#FF33B8", // Rose
     "#8CFF33", // Lime Green
@@ -532,7 +532,9 @@ export default function Map({ raidData, profileId, raidId, positions }) {
 
                 }
 
-                const pickedColor = colors[i % colors.length];
+                const player = raidData.players.find(p => p.profileId === currentIndexId);
+                const index = raidData.players.findIndex(p => p.profileId === currentIndexId);
+                const pickedColor = getPlayerColor(player, index);
 
                 // Hide player movement if enabled
                 if (!hidePlayers && MAP && cleanPositions.length > 0) {
@@ -696,7 +698,12 @@ export default function Map({ raidData, profileId, raidId, positions }) {
           else return player.mod_SAIN_brain != null ? `(${player.mod_SAIN_brain})` : "(PMC)"
         }
         return "(UNKNOWN)"
-      }
+    }
+
+    function getPlayerColor(player: TrackingRaidDataPlayers, index: number): string {
+        if (player && player.team === 'Savage') return "#33FF57"; // Green - Scav (bosses and raiders included for now)
+        else return colors[index]; // PMC
+    }
 
     return (
         <div className="map-container" key="map-wrapper">
@@ -716,7 +723,7 @@ export default function Map({ raidData, profileId, raidId, positions }) {
                             { raidData.players.filter(p => p.spawnTime < timeEndLimit).map((player, index) => 
                                 <li className="flex items-center justify-between player-legend-item px-2" key={player.profileId} onMouseEnter={() => setPlayerFocus(index)} onMouseLeave={() => setPlayerFocus(null)} onClick={() => {setFollowPlayer(followPlayer === index ? 999999 : index); setFollowPlayerZoomed(false);}}>
                                     <div className={`flex flex-row items-center ${playerWasKilled(player.profileId, timeEndLimit)? "line-through opacity-25": ""}`}>
-                                        <span style={{width: '8px', height: '8px', borderRadius: '50%', marginRight: '8px', background : colors[index]}}></span>
+                                        <span style={{width: '8px', height: '8px', borderRadius: '50%', marginRight: '8px', background : getPlayerColor(player, index)}}></span>
                                         <span>
                                             {player.name} {getPlayerBrain(player)}
                                         </span>

--- a/Server/src/Web/Client/src/pages/Raid.tsx
+++ b/Server/src/Web/Client/src/pages/Raid.tsx
@@ -190,11 +190,21 @@ export default function Raid() {
 
   function getPlayerBrain(player: TrackingRaidDataPlayers): string {
     if(player) {
-      if (player.team === "Savage") {
-        return "";
-      } else return player.mod_SAIN_brain != null ? player.mod_SAIN_brain : "UNKNOWN";
-    }
-    return "UNKNOWN"
+      switch (player.type){
+          case 'BOSS':
+              return "BOSS"
+          case 'RAIDER':
+              return "RAIDER"
+          case 'PLAYER_SCAV':
+              return "PLAYER SCAV"
+          default:
+              if(player.team === "Savage") {
+                return ""
+              } 
+              return player.mod_SAIN_brain != null ? `(${player.mod_SAIN_brain})` : "(PMC)"
+      }
+  }
+  return "(UNKNOWN)"
   }
 
   function generateTimeline(filters: string[]): any {

--- a/Server/src/mod.ts
+++ b/Server/src/mod.ts
@@ -231,7 +231,7 @@ class Mod implements IPreAkiLoadMod, IPostAkiLoadMod {
                 break;
                 
               case "PLAYER":
-                const player_sql = `INSERT INTO player (raidId, profileId, level, team, name, "group", spawnTime, mod_SAIN_brain) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
+                const player_sql = `INSERT INTO player (raidId, profileId, level, team, name, "group", spawnTime, mod_SAIN_brain, type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`;
                 this.database
                   .run(player_sql, [
                     this.raid_id,
@@ -241,7 +241,8 @@ class Mod implements IPreAkiLoadMod, IPostAkiLoadMod {
                     payload_object.name,
                     payload_object.group,
                     payload_object.spawnTime,
-                    payload_object.mod_SAIN_brain
+                    payload_object.mod_SAIN_brain,
+                    payload_object.type
                   ])
                   .catch((e: Error) => console.error(e));
 


### PR DESCRIPTION
Fix SAIN mod detection.

Added detection of bots types and gives them a color:
- Scavs : Green
- Raiders : Magenta
- Bosses : Red

![image](https://github.com/ekky-llc/spt-raid-review/assets/16125208/774d5567-9ed7-4ee9-a1ca-e7fc33817881)

Add a "type" column to the "player" table.