### PR TITLE
Fix delay on map playback, better SAIN bot info retrieval

### DIFF
--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -21,6 +21,7 @@ using SAIN.SAINComponent.Classes.Info;
 using EFT.Communications;
 using System.Threading.Tasks;
 using System.Linq;
+using SAIN.Components;
 
 namespace RAID_REVIEW
 {
@@ -72,6 +73,9 @@ namespace RAID_REVIEW
         {
             get; set;
         }
+        public static SAINBotController sainBotController { get; set; }
+        public static bool searchingForSainComponents = false;
+        public static Dictionary<string, TrackingPlayer> updatedBots = new Dictionary<string, TrackingPlayer>();
 
         void Awake()
         {
@@ -170,63 +174,14 @@ namespace RAID_REVIEW
                             mod_SAIN_brain = "UNKNOWN"
                         };
 
-                        // Get player mod_SAIN brain type name
-
-                        if (SOLARINT_SAIN__DETECTED)
+                        if (player.Side == EPlayerSide.Savage)
                         {
-                            BotComponent botComponent = null;
-
-                            int maxRetries = 10;
-                            int retryCount = 0;
-                            int retryIntervalMilliseconds = 2000;
-
-                            while (botComponent == null && retryCount < maxRetries)
-                            {
-                                botComponent = player.gameObject.GetComponent<BotComponent>();
-
-                                if (botComponent == null)
-                                {
-                                    await Task.Delay(retryIntervalMilliseconds); // Wait for the specified interval
-                                    retryCount++;
-                                }
-                            }
-
-
-                            if (botComponent != null)
-                            {
-                                var brain = botComponent.Info.Personality;
-                                trackingPlayer.mod_SAIN_brain = Enum.GetName(typeof(EPersonality), brain);
-
-                                if (!botComponent.Info.Profile.IsPMC)
-                                {
-                                    trackingPlayer.type = BotHelper.getBotType(botComponent);
-                                }
-
-                            } 
-                            else 
-                            {
-                                if (player.Side == EPlayerSide.Savage)
-                                {
-                                    trackingPlayer.mod_SAIN_brain = "SCAV";
-                                    trackingPlayer.type = "SCAV|SCAV";
-                                }
-
-                                if (player.Side == EPlayerSide.Usec || player.Side == EPlayerSide.Bear)
-                                {
-                                    trackingPlayer.mod_SAIN_brain = "PMC";
-                                }
-                            }
+                            trackingPlayer.mod_SAIN_brain = "SCAV";
+                            trackingPlayer.type = "SCAV|SCAV";
                         }
-                        else
+                        else if (player.Side == EPlayerSide.Usec || player.Side == EPlayerSide.Bear)
                         {
-                            if (player.Side == EPlayerSide.Savage) {
-                                trackingPlayer.mod_SAIN_brain = "SCAV";
-                                trackingPlayer.type = "SCAV|SCAV";
-                            }
-
-                            if (player.Side == EPlayerSide.Usec || player.Side == EPlayerSide.Bear) {
-                                trackingPlayer.mod_SAIN_brain = "PMC";
-                            }
+                            trackingPlayer.mod_SAIN_brain = "PMC";
                         }
 
                         trackingPlayers[trackingPlayer.profileId] = trackingPlayer;

--- a/Client/patches/player_onGameSessionEndPatch.cs
+++ b/Client/patches/player_onGameSessionEndPatch.cs
@@ -24,6 +24,9 @@ namespace RAID_REVIEW
 
                 RAID_REVIEW.tracking = false;
                 RAID_REVIEW.inRaid = false;
+                RAID_REVIEW.searchingForSainComponents = false;
+                RAID_REVIEW.updatedBots.Clear();
+                RAID_REVIEW.sainBotController = null;
 
                 RAID_REVIEW.stopwatch.Stop();
                 RAID_REVIEW.trackingRaid.profileId = __instance.ProfileId;

--- a/Client/patches/player_onGameStartedPatch.cs
+++ b/Client/patches/player_onGameStartedPatch.cs
@@ -106,7 +106,10 @@ namespace RAID_REVIEW
                     if (RAID_REVIEW.gameWorld != null)
                     {
                         RAID_REVIEW.sainBotController = RAID_REVIEW.gameWorld.GetComponent<SAINBotController>();
-                        Logger.LogInfo("RAID_REVIEW :::: INFO :::: SAIN Bot Controller Found");
+                        if(RAID_REVIEW.sainBotController != null)
+                            Logger.LogInfo("RAID_REVIEW :::: INFO :::: SAIN Bot Controller Found");
+                        else
+                            Logger.LogInfo("RAID_REVIEW :::: INFO :::: SAIN Bot Controller Not Found");
                     }
                     else
                     {

--- a/Server/src/Web/Client/src/component/MapComponent.tsx
+++ b/Server/src/Web/Client/src/component/MapComponent.tsx
@@ -201,14 +201,6 @@ const colors = [
     "#33FFF3", // Aqua
 ];
 
-export function isGoon(player) {
-    if (player !== undefined) {
-        let goons = ["Big Pipe", "Birdeye", "Knight"];
-        return goons.includes(player.name);
-    }
-    return false;
-}
-
 export default function MapComponent({ raidData, profileId, raidId, positions }) {
     const navigate = useNavigate();
     const [ searchParams ] = useSearchParams();
@@ -743,8 +735,6 @@ export default function MapComponent({ raidData, profileId, raidId, positions })
                 return `(${player.mod_SAIN_brain.trim()})`;
             }
 
-            if (isGoon(player)) botMapping.type = "GOON";
-
             if (player.mod_SAIN_brain === 'PLAYER') brainOutput = "(Human)"
             if (player.mod_SAIN_brain != null) brainOutput = `(${player.mod_SAIN_brain.trim()})`;
 
@@ -774,10 +764,6 @@ export default function MapComponent({ raidData, profileId, raidId, positions })
             botMapping = {
                 type: 'UNKNOWN'
             };
-        }
-
-        if (isGoon(player)) {
-            botMapping.type = "GOON";
         }
 
         switch (botMapping.type) {

--- a/Server/src/Web/Client/src/pages/Raid.tsx
+++ b/Server/src/Web/Client/src/pages/Raid.tsx
@@ -10,7 +10,6 @@ import "./Raid.css";
 import { TrackingRaidData, TrackingRaidDataPlayers } from "../types/api_types";
 import { locations } from "./Profile";
 import { getCookie } from "../modules/utils";
-import { isGoon } from "../component/MapComponent";
 
 export async function loader(loaderData: any) {
   const profileId = loaderData.params.profileId as string;
@@ -58,10 +57,6 @@ export default function Raid() {
     }
 
     const groupedPlayers = _.chain(raidData.players).map(p => {
-
-      if (isGoon(p)) {
-        p.group = 12345;
-      }
 
       return {
         ...p,
@@ -205,10 +200,6 @@ export default function Raid() {
           botMapping = {
               type: 'UNKNOWN'
           };
-      }
-      
-      if (isGoon(player)) {
-        botMapping.type = "GOON";
       }
     
       switch (botMapping.type){

--- a/Server/src/mod.ts
+++ b/Server/src/mod.ts
@@ -304,7 +304,16 @@ class Mod implements IPreAkiLoadMod, IPostAkiLoadMod {
                   .catch((e: Error) => console.error(e));
 
                 break;
-
+              case "PLAYER_UPDATE":
+                const player_update_sql = 'UPDATE player SET mod_SAIN_brain = ?, type = ? WHERE raidId = ? AND profileId = ?';
+                this.database.run(player_update_sql, [
+                  payload_object.mod_SAIN_brain,
+                  payload_object.type,
+                  this.raid_id,
+                  payload_object.profileId
+                ])
+                .catch((e: Error) => console.error(e));
+                break;
               case "KILL":
                 const kill_sql = `INSERT INTO kills (raidId, time, profileId, killedId, weapon, distance, bodyPart, positionKiller, positionKilled) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`;
                 this.database


### PR DESCRIPTION
- Removal of the SAIN component retry loop, which solves the problem of map playback delay.
- Added an asynchronous method for retrieving SAIN components.
- Added a new ws action payload to update a player.
- Removal of unneeded isGoon verification by the client (it works without it now).

Note: I've set bot info retrieval to every 10s, so if a bot appears and dies within 10s, its SAIN info won't be retrieved (which can sometimes happen on Factory).