### PR TITLE
Fix - Firefox rendering

### DIFF
--- a/Private/src/component/MapPlayerSlider.tsx
+++ b/Private/src/component/MapPlayerSlider.tsx
@@ -83,6 +83,11 @@ export function PlayerSlider({ sliderTimes, events, timeCurrentIndex, setTimeCur
         setTimeEndLimit(sliderTimes[newIndex]);
     };
 
+    // Fixes rendering in Firefox
+    useEffect(() => {
+        sliderTimes.sort((a, b) => a - b);
+    }, [sliderTimes]);
+    
     useEffect(() => {
         if (isDragging) {
             document.addEventListener('mousemove', handleMouseMove);


### PR DESCRIPTION
Firefox loads the sliderTimes array in descending order while Chrome loads in ascending order.
This change sorts the array to ensure consistency across both Chrome and Firefox.

This fixes event positioning on the timeline as well as player and event positioning in the map playback.