### PR TITLE
Add Sandbox_high (Ground Zero for > lvl 20)

### DIFF
--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -254,6 +254,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
         const locations = {
             bigmap: 'customs',
             Sandbox: 'ground-zero',
+            Sandbox_high: 'ground-zero',
             develop: 'ground-zero',
             factory4_day: 'factory',
             factory4_night: 'factory',

--- a/Private/src/helpers/locations.ts
+++ b/Private/src/helpers/locations.ts
@@ -1,6 +1,7 @@
 export const LOCATIONS: { [key: string]: string } = {
     "bigmap": "Customs",
     "Sandbox": "Ground Zero",
+    "Sandbox_high": "Ground Zero",
     "develop": "Ground Zero",
     "factory4_day": "Factory",
     "factory4_night": "Factory",

--- a/Server/types/models/enums/ELocationName.d.ts
+++ b/Server/types/models/enums/ELocationName.d.ts
@@ -5,6 +5,7 @@ export declare enum ELocationName {
     WOODS = "Woods",
     SHORELINE = "Shoreline",
     SANDBOX = "Sandbox",
+    SANDBOX_HIGH = "Sandbox_high",
     INTERCHANGE = "Interchange",
     LIGHTHOUSE = "Lighthouse",
     LABORATORY = "laboratory",


### PR DESCRIPTION
# Background
[SPT v3.9.0](https://dev.sp-tarkov.com/SPT/Stable-releases/releases/tag/3.9.0) separated the Ground Zero maps into Sandbox and Sandbox_high (for > lvl 20), like in live Tarkov.
- See commit https://dev.sp-tarkov.com/SPT-AKI/Server/commit/3e99f6761f12c45296ca160112cddfa8a2a5eb33

# Issue
Raids run on Ground Zero when > lvl 20 are now on the map `Sandbox_high`, which Raid Review cannot handle entirely. It will record the raid and it will be visible in the list of raids, but when trying to access the map it will not load:

![Screenshot_2024-08-06_at_4 53 11_PM](https://github.com/user-attachments/assets/8c4c1224-b9da-4ca4-987a-bd0a52d84e5b)

If you then try to scan through the raid, you'll see the following errors:

![Screenshot_2024-08-06_at_4 50 30_PM](https://github.com/user-attachments/assets/d25eb6f4-f335-4906-acdc-628345698d84)

# Proposed Solution
The differences in live, to my knowledge, are primarily the loot pools and the boss spawn, which shouldn't really affect Raid Review, so I propose that Raid Review just treat it like Ground Zero with a different name.

## Changes

As a quick test, I just edited two places in`Server\src\Server\public\assets\index-7d0f19c6.js` live on my server, which fixed it for the time being, but I believe that is a generated file and not the right way to fix this. (Someone please confirm that as I've not done any Javascript/Typescript so I'm shooting a bit in the dark here). I'm confident these files needed to be updated and I'm looking to see if there are others that need to be updated as well.