### PR TITLE
Cleanup taskbar menu entry

### DIFF
--- a/Client/menu.cs
+++ b/Client/menu.cs
@@ -31,59 +31,66 @@ namespace RAID_REVIEW
 
                     foreach (Transform child in duplicatedToggleGroup.transform)
                     {
-                        child.name = "StatMod_Child";
-
-                        AnimatedToggle childAnimatedToggle = child.GetComponent<AnimatedToggle>();
-                        if (childAnimatedToggle != null)
+                        if (child.name == "NewInformation")
                         {
-                            childAnimatedToggle.onValueChanged.AddListener((value) =>
-                            {
-                                if (value)
-                                {
-                                    Application.OpenURL(RAID_REVIEW.RAID_REVIEW_HTTP_Server);
-                                    childAnimatedToggle.isOn = false;
-                                }
-                            });
+                            Destroy(child.gameObject);
                         }
-
-                        foreach (Transform subChild in child.transform)
+                        else
                         {
-                            if (subChild.name == "Text")
+                            child.name = "StatMod_Child";
+
+                            AnimatedToggle childAnimatedToggle = child.GetComponent<AnimatedToggle>();
+                            if (childAnimatedToggle != null)
                             {
-                                LocalizedText subChildEftText = subChild.GetComponent<LocalizedText>();
-                                if (subChildEftText != null)
+                                childAnimatedToggle.onValueChanged.AddListener((value) =>
                                 {
-
-                                    if (subChildEftText.LocalizationKey == "HANDBOOK")
+                                    if (value)
                                     {
-                                        subChildEftText.LocalizationKey = "RAID REVIEW";
+                                        Application.OpenURL(RAID_REVIEW.RAID_REVIEW_HTTP_Server);
+                                        childAnimatedToggle.isOn = false;
                                     }
+                                });
+                            }
 
-                                    // Use reflection to update all public string fields and properties
-                                    Type type = subChildEftText.GetType();
-                                    PropertyInfo[] properties = type.GetProperties();
-                                    FieldInfo[] fields = type.GetFields();
-
-                                    foreach (var property in properties)
+                            foreach (Transform subChild in child.transform)
+                            {
+                                if (subChild.name == "Text")
+                                {
+                                    LocalizedText subChildEftText = subChild.GetComponent<LocalizedText>();
+                                    if (subChildEftText != null)
                                     {
-                                        if (property.PropertyType == typeof(string) && property.CanWrite)
+
+                                        if (subChildEftText.LocalizationKey == "HANDBOOK")
                                         {
-                                            string value = (string)property.GetValue(subChildEftText);
-                                            if (value == "HANDBOOK")
+                                            subChildEftText.LocalizationKey = "RAID REVIEW";
+                                        }
+
+                                        // Use reflection to update all public string fields and properties
+                                        Type type = subChildEftText.GetType();
+                                        PropertyInfo[] properties = type.GetProperties();
+                                        FieldInfo[] fields = type.GetFields();
+
+                                        foreach (var property in properties)
+                                        {
+                                            if (property.PropertyType == typeof(string) && property.CanWrite)
                                             {
-                                                property.SetValue(subChildEftText, "RAID REVIEW");
+                                                string value = (string)property.GetValue(subChildEftText);
+                                                if (value == "HANDBOOK")
+                                                {
+                                                    property.SetValue(subChildEftText, "RAID REVIEW");
+                                                }
                                             }
                                         }
-                                    }
 
-                                    foreach (var field in fields)
-                                    {
-                                        if (field.FieldType == typeof(string))
+                                        foreach (var field in fields)
                                         {
-                                            string value = (string)field.GetValue(subChildEftText);
-                                            if (value == "HANDBOOK")
+                                            if (field.FieldType == typeof(string))
                                             {
-                                                field.SetValue(subChildEftText, "RAID REVIEW");
+                                                string value = (string)field.GetValue(subChildEftText);
+                                                if (value == "HANDBOOK")
+                                                {
+                                                    field.SetValue(subChildEftText, "RAID REVIEW");
+                                                }
                                             }
                                         }
                                     }

--- a/Client/menu.cs
+++ b/Client/menu.cs
@@ -14,7 +14,7 @@ namespace RAID_REVIEW
         public static Boolean Insert()
         {
             List<ToggleGroup> toggleGroups = new List<ToggleGroup>(UnityEngine.Object.FindObjectsOfType<ToggleGroup>());
-            ToggleGroup toggleGroupExists = toggleGroups.Find((toggleGroupItem) => toggleGroupItem.name == "StatMod");
+            ToggleGroup toggleGroupExists = toggleGroups.Find((toggleGroupItem) => toggleGroupItem.name == "RaidReview");
 
             if (toggleGroupExists != null)
             {
@@ -27,7 +27,7 @@ namespace RAID_REVIEW
                 {
                     ToggleGroup duplicatedToggleGroup = Instantiate(toggleGroup, toggleGroup.transform.parent);
 
-                    duplicatedToggleGroup.name = "StatMod";
+                    duplicatedToggleGroup.name = "RaidReview";
 
                     foreach (Transform child in duplicatedToggleGroup.transform)
                     {
@@ -37,7 +37,7 @@ namespace RAID_REVIEW
                         }
                         else
                         {
-                            child.name = "StatMod_Child";
+                            child.name = "RaidReviewButton";
 
                             AnimatedToggle childAnimatedToggle = child.GetComponent<AnimatedToggle>();
                             if (childAnimatedToggle != null)


### PR DESCRIPTION
This PR stop an undismissable yellow box from appearing above the `RAID REVIEW MOD` menu button.

# Issue
If there are unread handbook entries they will show as a number or `>99` in a yellow box above the `HANDBOOK` button on the bottom menu bar. If there are unread entries, and thus the yellow box, when `EscapeFromTarkov.exe` was launched the `RAID REVIEW MOD` button will have a matching yellow box. The unread entries above `HANDBOOK` can be dismissed by clicking on the yellow icon or going through each entry in the `HANDBOOK` but the one above the `RAID REVIEW MOD` can not be dismissed and will remain until the game is restarted.

### Before (current release v0.2.0)
On Launch

![Screenshot 2024-10-27 at 10 03 39 PM](https://github.com/user-attachments/assets/652ad0c3-4ec3-4758-a766-12ee0a57c018)

After dismissing the entries above `HANDBOOK`, the yellow box remains above `RAID REVIEW MOD`

![Screenshot 2024-10-27 at 10 03 51 PM](https://github.com/user-attachments/assets/27fdd482-bc2e-4403-bb8c-9c55669d582f)

# Fix
This is an issue due to duplicating the `HANDBOOK` with all of it's children objects. This PR deletes any children of the new object that have the name `NewInformation` as that is the child object that is this yellow box.

### After (with this PR)

On Launch there is only a yellow box above `HANDBOOK`

![Screenshot 2024-10-27 at 10 26 26 PM](https://github.com/user-attachments/assets/caa30863-4664-45ac-93b8-2b4bd5000a4b)

After dismissing the entries above `HANDBOOK`, there is no yellow box anywhere

![Screenshot 2024-10-27 at 10 26 34 PM](https://github.com/user-attachments/assets/a9d03f1b-6453-467b-a114-0f7ddfa30ea2)

## Alternate Fixes
We could just duplicate a different menu option that doesn't ever have a yellow box. That seems to be what is done in the fika plugin (https://github.com/project-fika/Fika-Plugin/blob/main/Fika.Core/UI/Patches/MenuTaskBar_Patch.cs) which uses the `FleaMarket` instead. I just didn't think about it until I was already done with this but I'm open to changing to that and getting rid of the additional if/else branch I've added here.

# Notes
### Button Text
`RAID REVIEW MOD` was renamed to`RAID REVIEW` in a previous commit that is not in the current release, thus the difference in the button text in the screenshots.

### Files changed
The Github Files changed tab above is a bit deceptive as most of the changes were actually whitespace from adding indentation due to an additional if/else statement. If you have it filter whitespace using the gear icon (pictured) it will look like this

![Screenshot 2024-10-27 at 11 04 56 PM](https://github.com/user-attachments/assets/956196c3-b7bb-4e01-856e-2ce8e5100d6d)

### Renaming objects
This has no real bearing on the functionality but I was in the area anyways so I rename the objects of this button from `StatMod` and `StatMod_Child` to `RaidReview` and `RaidReviewButton` to match the naming convention used by the other buttons.